### PR TITLE
Add docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,39 @@
 version: "3.8"
 
 services:
+  horizon-database:
+    image:  mcr.microsoft.com/mssql/server:2019-latest
+    ports:
+      - 1433:1433
+    volumes:
+      - "${PWD}/data/":/var/opt/mssql
+    environment:
+      ACCEPT_EULA: "True"
+      MSSQL_SA_PASSWORD: admin
+      
+  horizon-middleware:
+    build: ../horizon-middleware
+    depends_on:
+      - horizon-database
+    ports:
+      - 10000:10000
+      - 10001:10001
+    environment:
+      DB_USER: admin
+      DB_PASSWORD: admin
+      DB_NAME: Medius_Database
+      DB_SERVER: horizon-database:1433
+      ASPNETCORE_ENVIRONMENT: Production
+      MIDDLEWARE_SERVER: http://0.0.0.0:10000
+      MIDDLEWARE_SERVER_IP: http://0.0.0.0:10000
+      MIDDLEWARE_USER: admin
+      MIDDLEWARE_PASSWORD: admin
+
   horizon-server:
     build: .
+    depends_on:
+      - horizon-database
+      - horizon-middleware
     ports:
       - 10071:10071
       - 10075:10075
@@ -23,30 +54,4 @@ services:
       MIDDLEWARE_PASSWORD: admin
       ASPNETCORE_ENVIRONMENT: Production
       ROBO_SALT: randomSalt
-
-  horizon-database:
-    image:  mcr.microsoft.com/mssql/server:2019-latest
-    ports:
-      - 1433:1433
-    volumes:
-      - "${PWD}/data/":/var/opt/mssql
-    environment:
-      ACCEPT_EULA: "True"
-      MSSQL_SA_PASSWORD: admin
-      
-  horizon-middleware:
-    build: ../horizon-middleware
-    ports:
-      - 10000:10000
-      - 10001:10001
-    environment:
-      DB_USER: admin
-      DB_PASSWORD: admin
-      DB_NAME: Medius_Database
-      DB_SERVER: horizon-database:1433
-      ASPNETCORE_ENVIRONMENT: Production
-      MIDDLEWARE_SERVER: http://0.0.0.0:10000
-      MIDDLEWARE_SERVER_IP: http://0.0.0.0:10000
-      MIDDLEWARE_USER: admin
-      MIDDLEWARE_PASSWORD: admin
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+version: "3.8"
+
+services:
+  horizon-server:
+    build: .
+    ports:
+      - 10071:10071
+      - 10075:10075
+      - 10077:10077
+      - 10078:10078
+      - 10073:10073
+      - 8281:8281
+      - 8765:8765
+      - 50000-50100:50000-50100/udp
+      - 10070:10070/udp
+    volumes:
+      - "${PWD}/logs":/logs
+      - "${PWD}/database:/database
+    environment:
+      MIDDLEWARE_SERVER_IP: horizon-middleware:10000
+      APP_ID: Unknown
+      MIDDLEWARE_USER: admin
+      MIDDLEWARE_PASSWORD: admin
+      ASPNETCORE_ENVIRONMENT: Production
+      ROBO_SALT: randomSalt
+
+  horizon-database:
+    image:  mcr.microsoft.com/mssql/server:2019-latest
+    ports:
+      - 1433:1433
+    volumes:
+      - "${PWD}/data/":/var/opt/mssql
+    environment:
+      ACCEPT_EULA: "True"
+      MSSQL_SA_PASSWORD: admin
+      
+  horizon-middleware:
+    build: ../horizon-middleware
+    ports:
+      - 10000:10000
+      - 10001:10001
+    environment:
+      DB_USER: admin
+      DB_PASSWORD: admin
+      DB_NAME: Medius_Database
+      DB_SERVER: horizon-database:1433
+      ASPNETCORE_ENVIRONMENT: Production
+      MIDDLEWARE_SERVER: http://0.0.0.0:10000
+      MIDDLEWARE_SERVER_IP: http://0.0.0.0:10000
+      MIDDLEWARE_USER: admin
+      MIDDLEWARE_PASSWORD: admin
+    


### PR DESCRIPTION
Docker compose allows you to put all of your `docker run` bash scripts into one spot. This puts all of them into one file to allow for a single command deployment. Instead of a multi-step command install.

Just `docker-compose up -d` and all of the containers will run at the same time.

Some notes:
- This is untested.
- I have no idea what `environment` variables are the ones I should be using.
---> Alternatively, I could make this file import a `.env` file which could be committed as: `docker.env.example` and then `.gitignore` the real `docker.env`