### PR TITLE
Add RT MSG Client Flush Single

### DIFF
--- a/RT.Models/RT/RT_MSG_CLIENT_FLUSH_SINGLE.cs
+++ b/RT.Models/RT/RT_MSG_CLIENT_FLUSH_SINGLE.cs
@@ -1,0 +1,38 @@
+using RT.Common;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Server.Common;
+using Server.Common.Stream;
+
+namespace RT.Models
+{
+    [ScertMessage(RT_MSG_TYPE.RT_MSG_CLIENT_FLUSH_SINGLE)]
+    public class RT_MSG_CLIENT_FLUSH_SINGLE : BaseScertMessage
+    {
+        public override RT_MSG_TYPE Id => RT_MSG_TYPE.RT_MSG_CLIENT_FLUSH_SINGLE;
+
+        public short TargetOrSource = 0;
+        public byte[] Payload;
+
+        public override void Deserialize(MessageReader reader)
+        {
+            TargetOrSource = reader.ReadInt16();
+            Payload = reader.ReadRest();
+        }
+
+        public override void Serialize(Server.Common.Stream.MessageWriter writer)
+        {
+            writer.Write(TargetOrSource);
+            writer.Write(Payload);
+        }
+
+        public override string ToString()
+        {
+            return base.ToString() + " " +
+                $"TargetOrSource:{TargetOrSource} " +
+                $"Payload:{(Payload == null ? "" : BitConverter.ToString(Payload)) }";
+        }
+    }
+}

--- a/Server.Dme/UdpServer.cs
+++ b/Server.Dme/UdpServer.cs
@@ -233,6 +233,11 @@ namespace Server.Dme
 
                         break;
                     }
+                case RT_MSG_CLIENT_FLUSH_SINGLE clientFlushSingle:
+                    {
+                        
+                        break;
+                    }
                 default:
                     {
                         Logger.Warn($"UNHANDLED MESSAGE: {message}");


### PR DESCRIPTION
Adds rt msg client flush single to prevent warning in logs for this packet. currently works without doing any processing (same as robo)