### PR TITLE
Fix regex filtering

### DIFF
--- a/Server.Medius/Medius/MAS.cs
+++ b/Server.Medius/Medius/MAS.cs
@@ -529,6 +529,16 @@ namespace Server.Medius
                             if (data.ClientObject == null)
                                 throw new InvalidOperationException($"INVALID OPERATION: {clientChannel} sent {accountLoginRequest} without a session.");
 
+                            // validate name
+                            if (!Program.PassTextFilter(data.ApplicationId, Config.TextFilterContext.ACCOUNT_NAME, accountLoginRequest.Username))
+                            {
+                                data.ClientObject.Queue(new MediusAccountLoginResponse()
+                                {
+                                    MessageID = accountLoginRequest.MessageID,
+                                    StatusCode = MediusCallbackStatus.MediusFail,
+                                });
+                                return;
+                            }
 
                             await Program.Plugins.OnEvent(PluginEvent.MEDIUS_ACCOUNT_LOGIN_REQUEST, new OnAccountLoginRequestArgs()
                             {
@@ -612,17 +622,6 @@ namespace Server.Medius
                                         {
                                         // Reply error
                                         data.ClientObject.Queue(new MediusAccountLoginResponse()
-                                            {
-                                                MessageID = accountLoginRequest.MessageID,
-                                                StatusCode = MediusCallbackStatus.MediusFail,
-                                            });
-                                            return;
-                                        }
-
-                                    // validate name
-                                    if (!Program.PassTextFilter(data.ApplicationId, Config.TextFilterContext.ACCOUNT_NAME, accountLoginRequest.Username))
-                                        {
-                                            data.ClientObject.Queue(new MediusAccountLoginResponse()
                                             {
                                                 MessageID = accountLoginRequest.MessageID,
                                                 StatusCode = MediusCallbackStatus.MediusFail,

--- a/Server.Medius/Program.cs
+++ b/Server.Medius/Program.cs
@@ -451,7 +451,7 @@ namespace Server.Medius
                 return true;
 
             Regex r = new Regex(rExp, RegexOptions.IgnoreCase | RegexOptions.Multiline);
-            return !r.IsMatch(text);
+            return r.IsMatch(text);
         }
 
         public static string FilterTextFilter(int appId, TextFilterContext context, string text)

--- a/Server.Medius/Program.cs
+++ b/Server.Medius/Program.cs
@@ -451,7 +451,7 @@ namespace Server.Medius
                 return true;
 
             Regex r = new Regex(rExp, RegexOptions.IgnoreCase | RegexOptions.Multiline);
-            return r.IsMatch(text);
+            return !r.IsMatch(text);
         }
 
         public static string FilterTextFilter(int appId, TextFilterContext context, string text)


### PR DESCRIPTION
- Account name filtering now applies to any login attempt, not only when account not found
- Regex filtering was not returning correctly