### PR TITLE
Add agg time ignore

### DIFF
--- a/Server.Dme/Config/AppSettings.cs
+++ b/Server.Dme/Config/AppSettings.cs
@@ -22,6 +22,11 @@ namespace Server.Dme.Config
         public int DefaultClientWorldAggTime { get; private set; } = 20;
 
         /// <summary>
+        /// If true, ignore client attemps to set agg time. Always use the default agg time from the app settings.
+        /// </summary>
+        public bool IgnoreClientSetAggTime { get; private set; } = false;
+
+        /// <summary>
         /// Number of seconds before the server should send an echo to the client.
         /// </summary>
         public int ServerEchoIntervalSeconds { get; private set; } = 5;
@@ -61,6 +66,9 @@ namespace Server.Dme.Config
             // DefaultClientWorldAggTime
             if (settings.TryGetValue("DefaultClientWorldAggTime", out value) && int.TryParse(value, out var defaultClientWorldAggTime))
                 DefaultClientWorldAggTime = defaultClientWorldAggTime;
+            // IgnoreClientSetAggTime
+            if (settings.TryGetValue("IgnoreClientSetAggTime", out value) && bool.TryParse(value, out var ignoreClientSetAggTime))
+                IgnoreClientSetAggTime = ignoreClientSetAggTime;
             // ServerEchoIntervalSeconds
             if (settings.TryGetValue("ServerEchoIntervalSeconds", out value) && int.TryParse(value, out var serverEchoIntervalSeconds))
                 ServerEchoIntervalSeconds = serverEchoIntervalSeconds;
@@ -84,6 +92,7 @@ namespace Server.Dme.Config
             {
                 { "EnableDmeEncryption", EnableDmeEncryption.ToString() },
                 { "DefaultClientWorldAggTime", DefaultClientWorldAggTime.ToString() },
+                { "IgnoreClientSetAggTime", IgnoreClientSetAggTime.ToString() },
                 { "ServerEchoIntervalSeconds", ServerEchoIntervalSeconds.ToString() },
                 { "KeepAliveGracePeriodSeconds", KeepAliveGracePeriodSeconds.ToString() },
                 { "ClientTimeoutSeconds", ClientTimeoutSeconds.ToString() },

--- a/Server.Dme/TcpServer.cs
+++ b/Server.Dme/TcpServer.cs
@@ -340,6 +340,8 @@ namespace Server.Dme
                             throw new Exception($"Client connected with invalid world id!");
 
                         data.ClientObject.ApplicationId = clientConnectTcpAuxUdp.AppId;
+                        data.ClientObject.AggTimeMs = Program.GetAppSettingsOrDefault(clientConnectTcpAuxUdp.AppId).DefaultClientWorldAggTime;
+
                         data.ClientObject.OnTcpConnected(clientChannel);
                         data.ClientObject.ScertId = GenerateNewScertClientId();
                         data.ClientObject.MediusVersion = scertClient.MediusVersion;
@@ -456,7 +458,8 @@ namespace Server.Dme
                     }
                 case RT_MSG_CLIENT_SET_AGG_TIME setAggTime:
                     {
-                        data.ClientObject.AggTimeMs = setAggTime.AggTime;
+                       if (!(Program.GetAppSettingsOrDefault(data.ClientObject.ApplicationId).IgnoreClientSetAggTime))
+                            data.ClientObject.AggTimeMs = setAggTime.AggTime;
                         break;
                     }
                 case RT_MSG_CLIENT_TIMEBASE_QUERY timebaseQuery:


### PR DESCRIPTION
This PR does 2 things:
1. Actually uses default agg time when no agg time is set. Previously agg time was being set to default on ClientObject initialization, but because the ApplicationId was not yet set on the ClientObject, it would not use the default from app settings. Now, on client_connect_aux_udp, it will successfully set the correct default agg time for that app id.
2. Adds `IgnoreClientSetAggTime` app setting which when set to `true`, will always ignore the client set agg time and use the server default.