### PR TITLE
Add ban check on echo recv

### DIFF
--- a/Server.Database/DbController.cs
+++ b/Server.Database/DbController.cs
@@ -699,6 +699,37 @@ namespace Server.Database
 
 
         /// <summary>
+        /// Check if an account is banned by Account Name, IP, or MAC
+        /// </summary>
+        /// <param name="accountName">Case insensitive name of player.</param>
+        /// <param name="appId">Application ID.</param>
+        /// <returns>Returns account.</returns>
+        public async Task<bool> GetAccountIsBanned(string accountName, int appId)
+        {
+            bool result = false;
+
+            try
+            {
+                if (_settings.SimulatedMode)
+                {
+                    result = false;
+                }
+                else
+                {
+                    accountName = HttpUtility.UrlEncode(accountName);
+                    string route = $"Account/checkAccountIsBanned?AccountName={accountName}&AppId={appId}";
+                    result = await GetDbAsync<bool>(route);
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e);
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Posts the given machine id to the database account with the given account id.
         /// </summary>
         /// <param name="accountId">Account id.</param>

--- a/Server.Medius/Config/AppSettings.cs
+++ b/Server.Medius/Config/AppSettings.cs
@@ -110,6 +110,11 @@ namespace Server.Medius.Config
         /// </summary>
         public int DmeTimeoutSeconds { get; private set; } = 30;
 
+        /// <summary>
+        /// Time, in seconds, between ban checks with the database on echo packets.
+        /// </summary>
+        public int BanEchoCheckCadenceSeconds {get; private set; } = 60;
+
         public AppSettings(int appId)
         {
             AppId = appId;
@@ -178,6 +183,9 @@ namespace Server.Medius.Config
             // DmeTimeoutSeconds
             if (settings.TryGetValue("DmeTimeoutSeconds", out value) && int.TryParse(value, out var dmeTimeoutSeconds))
                 DmeTimeoutSeconds = dmeTimeoutSeconds;
+            // BanEchoCheckCadenceSeconds
+            if (settings.TryGetValue("BanEchoCheckCadenceSeconds", out value) && int.TryParse(value, out var banEchoCheckCadenceSeconds))
+                BanEchoCheckCadenceSeconds = banEchoCheckCadenceSeconds;
         }
 
         public Dictionary<string, string> GetSettings()
@@ -205,6 +213,7 @@ namespace Server.Medius.Config
                 { "ClientLongTimeoutSeconds", ClientLongTimeoutSeconds.ToString() },
                 { "GameTimeoutSeconds", GameTimeoutSeconds.ToString() },
                 { "DmeTimeoutSeconds", DmeTimeoutSeconds.ToString() },
+                { "BanEchoCheckCadenceSeconds", BanEchoCheckCadenceSeconds.ToString() },
             };
         }
     }

--- a/Server.Medius/Medius/MLS.cs
+++ b/Server.Medius/Medius/MLS.cs
@@ -174,6 +174,7 @@ namespace Server.Medius
                                 // Banned
                                 QueueBanMessage(data);
                                 data.ClientObject.ForceDisconnect();
+                                data.ClientObject.Logout().GetAwaiter().GetResult();
                             }
                         });
                         break;

--- a/Server.Medius/Medius/MLS.cs
+++ b/Server.Medius/Medius/MLS.cs
@@ -174,7 +174,7 @@ namespace Server.Medius
                                 // Banned
                                 QueueBanMessage(data);
                                 data.ClientObject.ForceDisconnect();
-                                data.ClientObject.Logout().GetAwaiter().GetResult();
+                                _ = data.ClientObject.Logout();
                             }
                         });
                         break;

--- a/Server.Medius/Medius/MLS.cs
+++ b/Server.Medius/Medius/MLS.cs
@@ -164,20 +164,12 @@ namespace Server.Medius
 
                         Queue(new RT_MSG_CLIENT_ECHO() { Value = clientEcho.Value }, clientChannel);
 
-                        // Check if user is Account banned
-                        Program.Database.GetAccountByName(data.ClientObject.AccountName, data.ClientObject.ApplicationId).TimeoutAfter(_defaultTimeout).ContinueWith(async (r) =>
-                        {
-                            if (r.IsCompletedSuccessfully && r.Result != null && data != null && data.ClientObject != null && data.ClientObject.IsConnected)
-                            {
-                                if (r.Result.IsBanned)
-                                {
-                                    // Send ban message
-                                    QueueBanMessage(data);
-                                    data.ClientObject.ForceDisconnect();
-                                }
-                            }
-                        });
-
+                        // Check if player is banned.
+                        bool banned = await data.ClientObject.CheckBan();
+                        if (banned) {
+                            QueueBanMessage(data);
+                            data.ClientObject.ForceDisconnect();
+                        }
                         break;
                     }
                 case RT_MSG_CLIENT_APP_TOSERVER clientAppToServer:

--- a/Server.Medius/Medius/MLS.cs
+++ b/Server.Medius/Medius/MLS.cs
@@ -155,7 +155,6 @@ namespace Server.Medius
                     }
                 case RT_MSG_SERVER_ECHO serverEchoReply:
                     {
-
                         break;
                     }
                 case RT_MSG_CLIENT_ECHO clientEcho:
@@ -164,6 +163,21 @@ namespace Server.Medius
                             break;
 
                         Queue(new RT_MSG_CLIENT_ECHO() { Value = clientEcho.Value }, clientChannel);
+
+                        // Check if user is Account banned
+                        Program.Database.GetAccountByName(data.ClientObject.AccountName, data.ClientObject.ApplicationId).TimeoutAfter(_defaultTimeout).ContinueWith(async (r) =>
+                        {
+                            if (r.IsCompletedSuccessfully && r.Result != null && data != null && data.ClientObject != null && data.ClientObject.IsConnected)
+                            {
+                                if (r.Result.IsBanned)
+                                {
+                                    // Send ban message
+                                    QueueBanMessage(data);
+                                    data.ClientObject.ForceDisconnect();
+                                }
+                            }
+                        });
+
                         break;
                     }
                 case RT_MSG_CLIENT_APP_TOSERVER clientAppToServer:

--- a/Server.Medius/Medius/Models/ClientObject.cs
+++ b/Server.Medius/Medius/Models/ClientObject.cs
@@ -165,6 +165,16 @@ namespace Server.Medius.Models
         protected DateTime? _logoutTime = null;
 
         /// <summary>
+        /// The latest time a ban check occured from an echo
+        /// </summary>
+        private DateTime LastAccountBanCheckTime { get; set; } = Common.Utils.GetHighPrecisionUtcTime();
+
+        /// <summary>
+        /// If we need to check if they are banned from the database when an echo comes in from the client.
+        /// </summary>
+        private bool NeedToCheckBan => (Common.Utils.GetHighPrecisionUtcTime() - LastAccountBanCheckTime).TotalSeconds > Program.GetAppSettingsOrDefault(ApplicationId).BanEchoCheckCadenceSeconds;
+
+        /// <summary>
         /// 
         /// </summary>
         protected bool _hasActiveSession = true;
@@ -427,6 +437,33 @@ namespace Server.Medius.Models
                 CurrentGame = null;
             }
             DmeClientId = null;
+        }
+
+        public async Task<bool> CheckBan()
+        {
+            if (!NeedToCheckBan)
+                return false;
+
+            LastAccountBanCheckTime = Common.Utils.GetHighPrecisionUtcTime();
+
+            // Check if user is Account banned
+            var account = await Program.Database.GetAccountByName(AccountName, ApplicationId);
+            if (account == null)
+                return false;
+
+            if (account.IsBanned)
+                return true;
+
+            // Check if user is MAC banned
+            if (account.MachineId != null) {
+                bool isMacBanned = await Program.Database.GetIsMacBanned(account.MachineId);
+                if (isMacBanned != null && isMacBanned)
+                    return true;
+            }
+
+            // TODO: Add IP ban check
+
+            return false;
         }
 
         #endregion

--- a/Server.Medius/Medius/Models/ClientObject.cs
+++ b/Server.Medius/Medius/Models/ClientObject.cs
@@ -447,23 +447,7 @@ namespace Server.Medius.Models
             LastAccountBanCheckTime = Common.Utils.GetHighPrecisionUtcTime();
 
             // Check if user is Account banned
-            var account = await Program.Database.GetAccountByName(AccountName, ApplicationId);
-            if (account == null)
-                return false;
-
-            if (account.IsBanned)
-                return true;
-
-            // Check if user is MAC banned
-            if (account.MachineId != null) {
-                bool isMacBanned = await Program.Database.GetIsMacBanned(account.MachineId);
-                if (isMacBanned != null && isMacBanned)
-                    return true;
-            }
-
-            // TODO: Add IP ban check
-
-            return false;
+            return await Program.Database.GetAccountIsBanned(AccountName, ApplicationId);
         }
 
         #endregion


### PR DESCRIPTION
The reason for this PR is that bans will not force disconnect players from the game. Mac/IP/Account bans only apply on reconnect (leaving a game, logging in etc). 

With this change, a ban will happen within ~30 seconds and disconnect the player. 

This change is needed because players can login and not get disconnected by a ban. So they can sit in the game and have their name (with potentially a slur), sitting in lobby and showing in discord. Also, this will allow us to disconnect a player while they are in game.