### PR TITLE
fix: graceful disconnect + simulated mode defaults

### DIFF
--- a/Server.Database/DbController.cs
+++ b/Server.Database/DbController.cs
@@ -2566,7 +2566,11 @@ namespace Server.Database
                     if (_simulatedDb.AppSettings.TryGetValue(appId, out var settings))
                         return settings;
                     else
-                        return new Dictionary<string, string>();
+                        return new Dictionary<string, string>()
+                        {
+                            { "CreateAccountOnNotFound", "True" },
+                            { "EnableEncryption", "False" },
+                        };
                 }
                 else
                 {

--- a/Server.Medius/Medius/BaseMediusComponent.cs
+++ b/Server.Medius/Medius/BaseMediusComponent.cs
@@ -243,10 +243,10 @@ namespace Server.Medius
             // Disconnect and remove timedout unauthenticated channels
             while (_forceDisconnectQueue.TryDequeue(out var channel))
             {
-                // Send disconnect message
-                //_ = ForceDisconnectClient(channel);
-
                 _channelDatas.TryGetValue(channel.Id.AsLongText(), out var d);
+
+                // Send graceful disconnect notification before closing socket
+                await ForceDisconnectClient(channel);
 
                 // Logout
                 if (d?.ClientObject?.IsLoggedIn == true)
@@ -258,10 +258,10 @@ namespace Server.Medius
                 // 
                 Logger.Warn($"REMOVING CHANNEL {channel},{d},{d?.ClientObject}");
 
-                // close after 5 seconds
+                // Brief delay to let disconnect message flush, then close
                 _ = Task.Run(async () =>
                 {
-                    await Task.Delay(5000);
+                    await Task.Delay(500);
                     try
                     {
                         var closeTask = channel.CloseAsync();


### PR DESCRIPTION

## Summary

- **Graceful disconnect**: sends `RT_MSG_CLIENT_DISCONNECT_WITH_REASON` before `CloseAsync()` with a 500ms flush window, eliminating PCSX2 `DEV9: Shutdown SD_RECEIVE error: 107`
- **Simulated mode defaults**: `GetServerSettings` returns `CreateAccountOnNotFound=True` when no settings exist, so test servers allow first-time logins without database middleware

## Changed files

| File | Change |
|------|--------|
| `Server.Medius/Medius/BaseMediusComponent.cs` | Call `ForceDisconnectClient()` to send disconnect notification before socket close; reduce delay 5s→500ms |
| `Server.Database/DbController.cs` | Default `CreateAccountOnNotFound=True` and `EnableEncryption=False` in simulated mode |

## Why

The PCSX2 DEV9 layer logs `Shutdown SD_RECEIVE error: 107` (ENOTCONN) when the server abruptly closes TCP sockets without first sending an application-level disconnect. Sending `RT_MSG_CLIENT_DISCONNECT_WITH_REASON` before `CloseAsync()` gives the emulated PS2 network stack time to process the graceful shutdown.