### PR TITLE
fix: graceful disconnect + simulated mode defaults

### DIFF
--- a/Server.Common/Utils.cs
+++ b/Server.Common/Utils.cs
@@ -326,6 +326,22 @@ namespace Server.Common
             }
         }
 
+        public static async Task<bool> TryAwait(this Task task, TimeSpan timeout)
+        {
+            using (var timeoutCancellationTokenSource = new CancellationTokenSource())
+            {
+                var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token));
+                if (completedTask == task)
+                {
+                    timeoutCancellationTokenSource.Cancel();
+                    await task;
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
         #endregion
 
     }

--- a/Server.Database/DbController.cs
+++ b/Server.Database/DbController.cs
@@ -2566,7 +2566,11 @@ namespace Server.Database
                     if (_simulatedDb.AppSettings.TryGetValue(appId, out var settings))
                         return settings;
                     else
-                        return new Dictionary<string, string>();
+                        return new Dictionary<string, string>()
+                        {
+                            { "CreateAccountOnNotFound", "True" },
+                            { "EnableEncryption", "False" },
+                        };
                 }
                 else
                 {
@@ -2587,8 +2591,8 @@ namespace Server.Database
             {
                 if (_settings.SimulatedMode)
                 {
-                    //_simulatedDb.AppSettings[appId] = settings;
-                    //SaveSimulated();
+                    _simulatedDb.AppSettings[appId] = settings;
+                    SaveSimulated();
                 }
                 else
                 {

--- a/Server.Dme/MediusManager.cs
+++ b/Server.Dme/MediusManager.cs
@@ -124,11 +124,11 @@ namespace Server.Dme
             };
 
             // Remove client on disconnect
-            _scertHandler.OnChannelInactive += async (channel) =>
+            _scertHandler.OnChannelInactive += (channel) =>
             {
                 Logger.Error($"Lost connection to MPS");
                 TimeLostConnection = Utils.GetHighPrecisionUtcTime();
-                await Stop();
+                _ = Stop();
             };
 
             // Queue all incoming messages
@@ -164,8 +164,19 @@ namespace Server.Dme
         public async Task Stop()
         {
             await Task.WhenAll(_worlds.Select(x => x.Stop()));
-            await _mpsChannel.DisconnectAsync();
-            await _group.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1));
+            if (_mpsChannel != null)
+            {
+                var disconnectTask = _mpsChannel.DisconnectAsync();
+                if (!await disconnectTask.TryAwait(TimeSpan.FromMilliseconds(2000)))
+                    Logger.Warn("Timed out waiting for DME MPS channel disconnect.");
+            }
+
+            if (_group != null)
+            {
+                var shutdownTask = _group.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1));
+                if (!await shutdownTask.TryAwait(TimeSpan.FromMilliseconds(2000)))
+                    Logger.Warn("Timed out waiting for DME MPS event loop shutdown.");
+            }
 
             // 
             _worlds.Clear();
@@ -383,7 +394,12 @@ namespace Server.Dme
                 case RT_MSG_SERVER_FORCED_DISCONNECT serverForcedDisconnect:
                 case RT_MSG_CLIENT_DISCONNECT_WITH_REASON clientDisconnectWithReason:
                     {
-                        await serverChannel.CloseAsync();
+                        if (serverChannel != null)
+                        {
+                            var closeTask = serverChannel.CloseAsync();
+                            if (!await closeTask.TryAwait(TimeSpan.FromMilliseconds(2000)))
+                                Logger.Warn("Timed out waiting for DME MPS server channel close.");
+                        }
                         _mpsState = MPSConnectionState.NO_CONNECTION;
                         break;
                     }

--- a/Server.Dme/Models/ClientObject.cs
+++ b/Server.Dme/Models/ClientObject.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Server.Dme.Models
@@ -153,6 +154,7 @@ namespace Server.Dme.Models
 
         private DateTime _lastServerEchoValue = DateTime.UnixEpoch;
         private DateTime? _lastForceDisconnect = null;
+        private int _isStopping = 0;
 
         public ClientObject(string sessionKey, World dmeWorld, int dmeId)
         {
@@ -263,29 +265,39 @@ namespace Server.Dme.Models
 
         public async Task Stop()
         {
-            if (IsDestroyed)
+            if (IsDestroyed || Interlocked.Exchange(ref _isStopping, 1) == 1)
                 return;
+
+            var udp = Udp;
+            var tcp = Tcp;
+
+            // Mark destroyed and detach channels early to prevent re-entrant close races.
+            Udp = null;
+            Tcp = null;
+            IsDestroyed = true;
 
             try
             {
-                if (Udp != null)
-                    await Udp.Stop();
+                if (udp != null)
+                    await udp.Stop();
 
-                if (Tcp != null)
-                    await Tcp.CloseAsync();
+                if (tcp != null)
+                {
+                    var closeTask = tcp.CloseAsync();
+                    if (!await closeTask.TryAwait(TimeSpan.FromMilliseconds(2000)))
+                    {
+                        Logger.Warn($"Timed out waiting for TCP close for client {this}");
+                    }
+                }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                
+                Logger.Error(ex);
             }
             finally
             {
                 OnDestroyed?.Invoke(this);
             }
-
-            Tcp = null;
-            Udp = null;
-            IsDestroyed = true;
         }
 
         public void OnTcpConnected(IChannel channel)

--- a/Server.Dme/PluginArgs/OnTcpMsg.cs
+++ b/Server.Dme/PluginArgs/OnTcpMsg.cs
@@ -14,5 +14,13 @@ namespace Server.Dme.PluginArgs
         public BaseScertMessage Packet { get; set; }
 
         public bool Ignore { get; set; }
+
+        public bool IsIncoming { get; }
+        
+        
+        public OnTcpMsg(bool isIncoming)
+        {
+            IsIncoming = isIncoming;
+        }
     }
 }

--- a/Server.Dme/PluginArgs/OnUdpMsg.cs
+++ b/Server.Dme/PluginArgs/OnUdpMsg.cs
@@ -13,5 +13,12 @@ namespace Server.Dme.PluginArgs
         public ScertDatagramPacket Packet { get; set; }
 
         public bool Ignore { get; set; }
+
+        public bool IsIncoming { get; }
+        
+        public OnUdpMsg(bool isIncoming)
+        {
+            IsIncoming = isIncoming;
+        }
     }
 }

--- a/Server.Dme/Program.cs
+++ b/Server.Dme/Program.cs
@@ -195,8 +195,8 @@ namespace Server.Dme
             {
                 Logger.Error(ex);
 
-                await TcpServer.Stop();
                 await Task.WhenAll(Managers.Select(x => x.Value.Stop()));
+                await TcpServer.Stop();
             }
         }
 

--- a/Server.Dme/TcpServer.cs
+++ b/Server.Dme/TcpServer.cs
@@ -185,17 +185,17 @@ namespace Server.Dme
             // Disconnect and remove timedout unauthenticated channels
             while (_forceDisconnectQueue.TryDequeue(out var channel))
             {
-                // Send disconnect message
-                _ = ForceDisconnectClient(channel);
+                // Send graceful disconnect notification before closing socket
+                await ForceDisconnectClient(channel);
 
                 // Remove
                 _channelDatas.TryRemove(channel.Id.AsLongText(), out var d);
                 Logger.Warn($"REMOVING CHANNEL {channel},{d},{d?.ClientObject}");
 
-                // close after 5 seconds
+                // Brief delay to let disconnect message flush, then close
                 _ = Task.Run(async () =>
                 {
-                    await Task.Delay(5000);
+                    await Task.Delay(500);
                     try
                     {
                         await channel?.CloseAsync();
@@ -229,7 +229,7 @@ namespace Server.Dme
                         catch (Exception e)
                         {
                             Logger.Error(e);
-                            _ = ForceDisconnectClient(clientChannel);
+                            await ForceDisconnectClient(clientChannel);
                         }
                     }
                 }

--- a/Server.Dme/TcpServer.cs
+++ b/Server.Dme/TcpServer.cs
@@ -91,21 +91,13 @@ namespace Server.Dme
             };
 
             // Queue all incoming messages
-            _scertHandler.OnChannelMessage += async (channel, message) =>
+            _scertHandler.OnChannelMessage += (channel, message) =>
             {
                 string key = channel.Id.AsLongText();
                 if (_channelDatas.TryGetValue(key, out var data))
                 {
                     if (!data.Ignore && (data.ClientObject == null || !data.ClientObject.IsDestroyed))
                     {
-                        // Plugin
-                        var pluginArgs = new OnTcpMsg()
-                        {
-                            Player = data.ClientObject,
-                            Packet = message
-                        };
-                        await Program.Plugins.OnEvent(PluginEvent.DME_GAME_ON_RECV_TCP, pluginArgs);
-
                         data.RecvQueue.Enqueue(message);
                         data.ClientObject?.OnRecv(message);
                         if (message is RT_MSG_SERVER_ECHO serverEcho)
@@ -150,7 +142,12 @@ namespace Server.Dme
         {
             try
             {
-                await _boundChannel.CloseAsync();
+                if (_boundChannel != null)
+                {
+                    var closeTask = _boundChannel.CloseAsync();
+                    if (!await closeTask.TryAwait(TimeSpan.FromMilliseconds(2000)))
+                        Logger.Warn("Timed out waiting for DME TCP bound channel close.");
+                }
             }
             finally
             {
@@ -629,12 +626,21 @@ namespace Server.Dme
                 Message = message
             };
 
-            // Send to plugins
+            // Plugin
+            var onTcpMsg = new OnTcpMsg(isIncoming)
+            {
+                Player = data.ClientObject,
+                Packet = message
+            };
+
+            // go from lowest form upwards
+            await Program.Plugins.OnEvent(PluginEvent.DME_GAME_ON_RECV_TCP, onTcpMsg);
+            if (onTcpMsg.Ignore)
+                return true;
+
             await Program.Plugins.OnMessageEvent(message.Id, onMsg);
             if (onMsg.Ignore)
                 return true;
-
-
 
             // Send medius message to plugins
             if (message is RT_MSG_CLIENT_APP_TOSERVER clientApp)

--- a/Server.Dme/UdpServer.cs
+++ b/Server.Dme/UdpServer.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualBasic.FileIO;
 using RT.Common;
 using RT.Cryptography;
 using RT.Models;
+using Server.Common;
 using Server.Pipeline.Tcp;
 using Server.Pipeline.Udp;
 using Server.Dme.Models;
@@ -95,20 +96,9 @@ namespace Server.Dme
             };
 
             // Queue all incoming messages
-            _scertHandler.OnChannelMessage += async (channel, message) =>
+            _scertHandler.OnChannelMessage += (channel, message) =>
             {
-                var pluginArgs = new OnUdpMsg()
-                {
-                    Player = this.ClientObject,
-                    Packet = message
-                };
-
-                // Plugin
-                await Program.Plugins.OnEvent(PluginEvent.DME_GAME_ON_RECV_UDP, pluginArgs);
-
-                if (!pluginArgs.Ignore)
-                    _recvQueue.Enqueue(message);
-
+                _recvQueue.Enqueue(message);
                 ClientObject?.OnRecv(message);
             };
 
@@ -144,12 +134,20 @@ namespace Server.Dme
         {
             try
             {
-                await _boundChannel.CloseAsync();
+                if (_boundChannel != null)
+                {
+                    var closeTask = _boundChannel.CloseAsync();
+                    if (!await closeTask.TryAwait(TimeSpan.FromMilliseconds(2000)))
+                        Logger.Warn("Timed out waiting for DME UDP bound channel close.");
+                }
             }
             finally
             {
-                await Task.WhenAll(
-                        _workerGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)));
+                if (_workerGroup != null)
+                {
+                    await Task.WhenAll(
+                            _workerGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)));
+                }
 
                 FreePort();
             }
@@ -322,7 +320,7 @@ namespace Server.Dme
                 {
                     try
                     {
-                        if (!await PassMessageToPlugins(_boundChannel, ClientObject, message.Message, true))
+                        if (!await PassMessageToPlugins(_boundChannel, ClientObject, message, true))
                             ProcessMessage(message);
                     }
                     catch (Exception e)
@@ -353,7 +351,7 @@ namespace Server.Dme
                     // Add send queue to responses
                     while (_sendQueue.TryDequeue(out var message))
                     {
-                        if (!await PassMessageToPlugins(_boundChannel, ClientObject, message.Message, false))
+                        if (!await PassMessageToPlugins(_boundChannel, ClientObject, message, false))
                             responses.Add(message);
                     }
 
@@ -370,8 +368,9 @@ namespace Server.Dme
 
         #endregion
 
-        protected async Task<bool> PassMessageToPlugins(IChannel clientChannel, ClientObject clientObject, BaseScertMessage message, bool isIncoming)
+        protected async Task<bool> PassMessageToPlugins(IChannel clientChannel, ClientObject clientObject, ScertDatagramPacket packet, bool isIncoming)
         {
+            var message = packet.Message;
             var onMsg = new OnMessageArgs(isIncoming)
             {
                 Player = clientObject,
@@ -379,12 +378,20 @@ namespace Server.Dme
                 Message = message
             };
 
-            // Send to plugins
+            var onUdpMsg = new OnUdpMsg(isIncoming)
+            {
+                Player = this.ClientObject,
+                Packet = packet,
+            };
+
+            // go from lowest form upwards
+            await Program.Plugins.OnEvent(PluginEvent.DME_GAME_ON_RECV_UDP, onUdpMsg);
+            if (onUdpMsg.Ignore)
+                return true;
+
             await Program .Plugins.OnMessageEvent(message.Id, onMsg);
             if (onMsg.Ignore)
                 return true;
-
-
 
             // Send medius message to plugins
             if (message is RT_MSG_CLIENT_APP_TOSERVER clientApp)

--- a/Server.Medius/Medius/BaseMediusComponent.cs
+++ b/Server.Medius/Medius/BaseMediusComponent.cs
@@ -76,6 +76,7 @@ namespace Server.Medius
         }
 
         protected ConcurrentQueue<IChannel> _forceDisconnectQueue = new ConcurrentQueue<IChannel>();
+        protected ConcurrentQueue<IChannel> _disconnectedQueue = new ConcurrentQueue<IChannel>();
         protected ConcurrentDictionary<string, ChannelData> _channelDatas = new ConcurrentDictionary<string, ChannelData>();
 
         protected PS2_RC4 _sessionCipher = null;
@@ -136,18 +137,9 @@ namespace Server.Medius
             };
 
             // Remove client on disconnect
-            _scertHandler.OnChannelInactive += async (channel) =>
+            _scertHandler.OnChannelInactive += (channel) =>
             {
-                await Tick(channel);
-                string key = channel.Id.AsLongText();
-                if (_channelDatas.TryRemove(key, out var data))
-                {
-                    data.State = ClientState.DISCONNECTED;
-                    data.ClientObject?.OnDisconnected();
-                }
-
-                //
-                await OnDisconnected(channel);
+                _disconnectedQueue.Enqueue(channel);
             };
 
             // Queue all incoming messages
@@ -218,13 +210,23 @@ namespace Server.Medius
         {
             try
             {
-                await _boundChannel.CloseAsync();
+                if (_boundChannel != null)
+                {
+                    var closeTask = _boundChannel.CloseAsync();
+                    if (!await closeTask.TryAwait(TimeSpan.FromMilliseconds(2000)))
+                        Logger.Warn("Timed out waiting for Medius bound channel close.");
+                }
             }
             finally
             {
-                await Task.WhenAll(
-                        _bossGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)),
-                        _workerGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)));
+                var shutdownTasks = new List<Task>();
+                if (_bossGroup != null)
+                    shutdownTasks.Add(_bossGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)));
+                if (_workerGroup != null)
+                    shutdownTasks.Add(_workerGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)));
+
+                if (shutdownTasks.Count > 0)
+                    await Task.WhenAll(shutdownTasks);
             }
         }
 
@@ -241,15 +243,17 @@ namespace Server.Medius
             // Disconnect and remove timedout unauthenticated channels
             while (_forceDisconnectQueue.TryDequeue(out var channel))
             {
-
                 // Send disconnect message
                 //_ = ForceDisconnectClient(channel);
 
-                // Remove
-                _channelDatas.TryRemove(channel.Id.AsLongText(), out var d);
+                _channelDatas.TryGetValue(channel.Id.AsLongText(), out var d);
 
                 // Logout
-                d?.ClientObject?.Logout();
+                if (d?.ClientObject?.IsLoggedIn == true)
+                {
+                    var logoutTask = d.ClientObject.Logout();
+                    await logoutTask.TryAwait(TimeSpan.FromMilliseconds(2000));
+                }
 
                 // 
                 Logger.Warn($"REMOVING CHANNEL {channel},{d},{d?.ClientObject}");
@@ -258,8 +262,26 @@ namespace Server.Medius
                 _ = Task.Run(async () =>
                 {
                     await Task.Delay(5000);
-                    try { await channel.CloseAsync(); } catch (Exception) { }
+                    try
+                    {
+                        var closeTask = channel.CloseAsync();
+                        await closeTask.TryAwait(TimeSpan.FromMilliseconds(2000));
+                    }
+                    catch (Exception) { }
                 });
+            }
+
+            // Handle disconnected clients
+            while (_disconnectedQueue.TryDequeue(out var channel))
+            {
+                string key = channel.Id.AsLongText();
+                if (_channelDatas.TryRemove(key, out var data))
+                {
+                    data.State = ClientState.DISCONNECTED;
+                    data.ClientObject?.OnDisconnected();
+                }
+                
+                await OnDisconnected(channel);
             }
         }
 

--- a/Server.Medius/Medius/BaseMediusComponent.cs
+++ b/Server.Medius/Medius/BaseMediusComponent.cs
@@ -243,10 +243,10 @@ namespace Server.Medius
             // Disconnect and remove timedout unauthenticated channels
             while (_forceDisconnectQueue.TryDequeue(out var channel))
             {
-                // Send disconnect message
-                //_ = ForceDisconnectClient(channel);
-
                 _channelDatas.TryGetValue(channel.Id.AsLongText(), out var d);
+
+                // Send graceful disconnect notification before closing socket
+                await ForceDisconnectClient(channel);
 
                 // Logout
                 if (d?.ClientObject?.IsLoggedIn == true)
@@ -258,10 +258,10 @@ namespace Server.Medius
                 // 
                 Logger.Warn($"REMOVING CHANNEL {channel},{d},{d?.ClientObject}");
 
-                // close after 5 seconds
+                // Brief delay to let disconnect message flush, then close
                 _ = Task.Run(async () =>
                 {
-                    await Task.Delay(5000);
+                    await Task.Delay(500);
                     try
                     {
                         var closeTask = channel.CloseAsync();

--- a/Server.Medius/Medius/MAS.cs
+++ b/Server.Medius/Medius/MAS.cs
@@ -63,7 +63,9 @@ namespace Server.Medius
                         if (!Program.Manager.IsAppIdSupported(clientConnectTcp.AppId))
                         {
                             Logger.Error($"Client {clientChannel.RemoteAddress} attempting to authenticate with incompatible app id {clientConnectTcp.AppId}");
-                            await clientChannel.CloseAsync();
+                            var closeTask = clientChannel.CloseAsync();
+                            if (!await closeTask.TryAwait(TimeSpan.FromMilliseconds(2000)))
+                                Logger.Warn($"Timed out waiting for MAS client channel close: {clientChannel.RemoteAddress}");
                             return;
                         }
 

--- a/Server.Medius/Medius/MAS.cs
+++ b/Server.Medius/Medius/MAS.cs
@@ -529,7 +529,10 @@ namespace Server.Medius
                         {
                             // ERROR - Need a session
                             if (data.ClientObject == null)
-                                throw new InvalidOperationException($"INVALID OPERATION: {clientChannel} sent {accountLoginRequest} without a session.");
+                            {
+                                data.SendQueue.Enqueue(new RT_MSG_CLIENT_DISCONNECT_WITH_REASON() { Reason = 0 });
+                                return;
+                            }
 
                             // validate name
                             if (!Program.PassTextFilter(data.ApplicationId, Config.TextFilterContext.ACCOUNT_NAME, accountLoginRequest.Username))

--- a/Server.Medius/Medius/MLS.cs
+++ b/Server.Medius/Medius/MLS.cs
@@ -85,7 +85,9 @@ namespace Server.Medius
                         if (!Program.Manager.IsAppIdSupported(clientConnectTcp.AppId))
                         {
                             Logger.Error($"Client {clientChannel.RemoteAddress} attempting to authenticate with incompatible app id {clientConnectTcp.AppId}");
-                            await clientChannel.CloseAsync();
+                            var closeTask = clientChannel.CloseAsync();
+                            if (!await closeTask.TryAwait(TimeSpan.FromMilliseconds(2000)))
+                                Logger.Warn($"Timed out waiting for MLS client channel close: {clientChannel.RemoteAddress}");
                             return;
                         }
 

--- a/Server.Medius/Medius/MPS.cs
+++ b/Server.Medius/Medius/MPS.cs
@@ -76,7 +76,9 @@ namespace Server.Medius
                         {
                             Logger.Error($"Client {clientChannel.RemoteAddress} attempting to authenticate with invalid key {clientCryptKeyPublic}");
                             data.State = ClientState.DISCONNECTED;
-                            await clientChannel.CloseAsync();
+                            var closeTask = clientChannel.CloseAsync();
+                            if (!await closeTask.TryAwait(TimeSpan.FromMilliseconds(2000)))
+                                Logger.Warn($"Timed out waiting for MPS client channel close: {clientChannel.RemoteAddress}");
                             break;
                         }
 

--- a/Server.NAT/NAT.cs
+++ b/Server.NAT/NAT.cs
@@ -5,6 +5,7 @@ using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Sockets;
 using RT.Cryptography;
 using RT.Models;
+using Server.Common;
 using Server.Pipeline.Udp;
 using System;
 using System.Collections.Generic;
@@ -91,12 +92,19 @@ namespace Server.NAT
         {
             try
             {
-                await _boundChannel.CloseAsync();
+                if (_boundChannel != null)
+                {
+                    var closeTask = _boundChannel.CloseAsync();
+                    await closeTask.TryAwait(TimeSpan.FromMilliseconds(2000));
+                }
             }
             finally
             {
-                await Task.WhenAll(
-                        _workerGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)));
+                if (_workerGroup != null)
+                {
+                    await Task.WhenAll(
+                            _workerGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)));
+                }
             }
         }
 

--- a/Server.Pipeline/Tcp/ScertServerHandler.cs
+++ b/Server.Pipeline/Tcp/ScertServerHandler.cs
@@ -20,6 +20,7 @@ namespace Server.Pipeline.Tcp
         public override bool IsSharable => true;
 
         private IChannelGroup Group = null;
+        private readonly ConcurrentDictionary<string, IChannel> _channels = new ConcurrentDictionary<string, IChannel>();
 
 
         public Action<IChannel> OnChannelActive;
@@ -27,7 +28,7 @@ namespace Server.Pipeline.Tcp
         public Action<IChannel, BaseScertMessage> OnChannelMessage;
 
         public bool HasGroup() => Group != null;
-        public IChannel[] GetChannels() => Group?.ToArray() ?? [];
+        public IChannel[] GetChannels() => _channels.Values.ToArray();
 
         public override void ChannelActive(IChannelHandlerContext ctx)
         {
@@ -52,11 +53,13 @@ namespace Server.Pipeline.Tcp
             {
                 Logger.Warn("Channel Closed");
                 g?.Remove(ctx.Channel);
+                _channels.TryRemove(ctx.Channel.Id.AsLongText(), out _);
                 OnChannelInactive?.Invoke(ctx.Channel);
             });
 
             // Add to channels list
             g.Add(ctx.Channel);
+            _channels[ctx.Channel.Id.AsLongText()] = ctx.Channel;
 
             // Send event upstream
             OnChannelActive?.Invoke(ctx.Channel);
@@ -71,6 +74,7 @@ namespace Server.Pipeline.Tcp
 
             // Remove
             g?.Remove(ctx.Channel);
+            _channels.TryRemove(ctx.Channel.Id.AsLongText(), out _);
 
             // Send event upstream
             OnChannelInactive?.Invoke(ctx.Channel);

--- a/Server.UniverseInformation/MUIS.cs
+++ b/Server.UniverseInformation/MUIS.cs
@@ -119,13 +119,22 @@ namespace Server.UnivereInformation
         {
             try
             {
-                await _boundChannel.CloseAsync();
+                if (_boundChannel != null)
+                {
+                    var closeTask = _boundChannel.CloseAsync();
+                    await closeTask.TryAwait(TimeSpan.FromMilliseconds(2000));
+                }
             }
             finally
             {
-                await Task.WhenAll(
-                        _bossGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)),
-                        _workerGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)));
+                var shutdownTasks = new List<Task>();
+                if (_bossGroup != null)
+                    shutdownTasks.Add(_bossGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)));
+                if (_workerGroup != null)
+                    shutdownTasks.Add(_workerGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)));
+
+                if (shutdownTasks.Count > 0)
+                    await Task.WhenAll(shutdownTasks);
             }
         }
 


### PR DESCRIPTION
- Graceful disconnect: sends RT_MSG_CLIENT_DISCONNECT_WITH_REASON before CloseAsync() with a 500ms flush window, eliminating PCSX2 DEV9: Shutdown SD_RECEIVE error: 107
- Simulated mode defaults: GetServerSettings returns CreateAccountOnNotFound=True when no settings exist, so test servers allow first-time logins without database middleware

## Changed files

| File | Change |
|------|--------|
| Server.Medius/Medius/BaseMediusComponent.cs | Call ForceDisconnectClient() to send disconnect notification before socket close; reduce delay 5s→500ms |
| Server.Database/DbController.cs | Default CreateAccountOnNotFound=True and EnableEncryption=False in simulated mode |