### PR TITLE
wait for db auth before starting network listeners

### DIFF
--- a/Server.Dme/Program.cs
+++ b/Server.Dme/Program.cs
@@ -198,6 +198,15 @@ namespace Server.Dme
 
             Logger.Info("Starting medius components...");
 
+            // wait for db auth before accepting connections
+            while (!await Database.AmIAuthenticated())
+            {
+                Logger.Info("Waiting for DB middleware to be ready...");
+                if (await Database.Authenticate())
+                    break;
+                await Task.Delay(1000);
+            }
+
             Logger.Info($"Starting TCP on port {TcpServer.Port}.");
             TcpServer.Start();
             Logger.Info($"TCP started.");

--- a/Server.Medius/Program.cs
+++ b/Server.Medius/Program.cs
@@ -170,6 +170,15 @@ namespace Server.Medius
 
             Logger.Info("Starting medius components...");
 
+            // wait for db auth before accepting connections
+            while (!await Database.AmIAuthenticated())
+            {
+                Logger.Info("Waiting for DB middleware to be ready...");
+                if (await Database.Authenticate())
+                    break;
+                await Task.Delay(1000);
+            }
+
             Logger.Info($"Starting MAS on port {AuthenticationServer.Port}.");
             AuthenticationServer.Start();
             Logger.Info($"MAS started.");


### PR DESCRIPTION
Prevents race when middleware boots slower than the server. DME and Medius now wait for initial DB auth before starting TCP/UDP listeners.